### PR TITLE
Make metadata optional

### DIFF
--- a/applications/geoportal-3d/main.js
+++ b/applications/geoportal-3d/main.js
@@ -21,9 +21,6 @@ import 'oskari-loader!oskari-frontend/packages/mapping/ol/infobox/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol/heatmap/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol/maprotator/bundle.js';
 
-import 'oskari-loader!oskari-frontend/packages/catalogue/metadatacatalogue/bundle.js';
-import 'oskari-loader!oskari-frontend/packages/catalogue/bundle/metadataflyout/bundle.js';
-
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/backendstatus/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/coordinatetool/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/guidedtour/bundle.js';

--- a/applications/geoportal/main.js
+++ b/applications/geoportal/main.js
@@ -16,8 +16,8 @@ import 'oskari-loader!oskari-frontend/packages/mapping/ol/infobox/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol/heatmap/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol/maprotator/bundle.js';
 
-import 'oskari-loader!oskari-frontend/packages/catalogue/metadatacatalogue/bundle.js';
-import 'oskari-loader!oskari-frontend/packages/catalogue/bundle/metadataflyout/bundle.js';
+import 'oskari-lazy-loader?metadatacatalogue!oskari-frontend/packages/catalogue/metadatacatalogue/bundle.js';
+import 'oskari-lazy-loader?metadataflyout!oskari-frontend/packages/catalogue/bundle/metadataflyout/bundle.js';
 
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/backendstatus/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/coordinatetool/bundle.js';


### PR DESCRIPTION
Frontend changes related to oskariorg/sample-server-extension#12

- Remove metadata related code from 3d as it's never used on the sample 3D app
- Load metadata related code if needed on geoportal as it's only used on the EPSG:3067 appsetup

Sample config updated to use Paikkatietohakemisto.fi as the CSW-service: https://github.com/oskariorg/sample-configs/commit/0c994c7248b2751459c8792887e4fffe218377a6. This is only relevant for Finland but the frontend is only showing metadata related functionality in the Finlanc centric example.