### PR TITLE
Clean up Cesium related code

### DIFF
--- a/applications/embedded-3d/index.js
+++ b/applications/embedded-3d/index.js
@@ -1,16 +1,3 @@
-// Loads Cesium-library and holds jQuery document ready until loaded.
-
-(function() {
-    jQuery.holdReady(true);
-    var CESIUM_LIB_URL = '/Oskari/libraries/Cesium/Cesium.js';
-    var script = document.createElement('script');
-    script.src = CESIUM_LIB_URL;
-    script.onload = function () {
-        jQuery.holdReady(false);
-    };
-    document.head.appendChild(script);
-}());
-
 jQuery(document).ready(function() {
     Oskari.app.loadAppSetup(ajaxUrl + 'action_route=GetAppSetup', window.controlParams, function() {
         jQuery('#mapdiv').append('Unable to start');

--- a/applications/geoportal-3d/index.js
+++ b/applications/geoportal-3d/index.js
@@ -1,33 +1,3 @@
-//Loads Cesium-library and holds jQuery document ready until loaded.
-
-(function() {
-    jQuery.holdReady(true);
-    var CESIUM_LIB_URL = '/Oskari/libraries/Cesium/Cesium.js';
-    var script = document.createElement('script');
-    script.src = CESIUM_LIB_URL;
-    script.onload = function () {
-        jQuery.holdReady(false);
-    };
-    document.head.appendChild(script);
-}());
-// Polyfills DOM4 MouseEvent for olcs
-(function (window) {
-    try {
-        new MouseEvent('test');
-        return false; // No need to polyfill
-    } catch (e) {
-        // Need to polyfill - fall through
-    }
-    var MouseEvent = function (eventType, params) {
-        params = params || { bubbles: false, cancelable: false };
-        var mouseEvent = document.createEvent('MouseEvent');
-        mouseEvent.initMouseEvent(eventType, params.bubbles, params.cancelable, window, 0, params.screenX || 0, params.screenY || 0, params.clientX || 0, params.clientY || 0, false, false, false, false, 0, null);
-        return mouseEvent;
-    }
-    MouseEvent.prototype = Event.prototype;
-    window.MouseEvent = MouseEvent;
-})(window);
-
 jQuery(document).ready(function() {
     function onSuccess () {
         var service = Oskari.getSandbox().getService('Oskari.map.DataProviderInfoService');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "start:dev": "npm run dev-mode:on && node ./node_modules/oskari-frontend/node_modules/webpack-dev-server/bin/webpack-dev-server.js --config ./node_modules/oskari-frontend/webpack.config.js --hot --env.appdef=devapp:applications",
     "build:dev": "npm run dev-mode:on && node ./node_modules/oskari-frontend/node_modules/webpack/bin/webpack.js --config ./node_modules/oskari-frontend/webpack.config.js --mode production --progress --env.appdef=applications",
     "sprite": "node ./node_modules/oskari-frontend/webpack/sprite.js",
-    "postinstall": "node ./node_modules/oskari-frontend/scripts/copy-cesium",
     "test": "eslint --config ./node_modules/oskari-frontend/.eslintrc.js bundles",
     "storybook": "npm run dev-mode:off && start-storybook"
   },


### PR DESCRIPTION
In oskariorg/oskari-frontend#1360 the Cesium stuff is included in mapmodule.olcs.js and oskari.min.js. So these can be removed from apps.