### PR TITLE
Replace bundles that were removed from Oskari

### DIFF
--- a/applications/embedded-3d/main.js
+++ b/applications/embedded-3d/main.js
@@ -19,9 +19,9 @@ import 'oskari-loader!oskari-frontend/packages/mapping/ol/drawtools/bundle.js';
 
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/coordinatetool/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/publishedstatehandler/bundle.js';
-import 'oskari-loader!oskari-frontend/packages/framework/featuredata2/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/rpc/bundle.js';
 
+import 'oskari-lazy-loader?featuredata2!oskari-frontend/packages/framework/featuredata2/bundle.js';
 import 'oskari-lazy-loader?statsgrid!oskari-frontend/packages/statistics/statsgrid/bundle.js';
 import 'oskari-lazy-loader?routingService!oskari-frontend/packages/framework/bundle/routingService/bundle.js';
 import 'oskari-lazy-loader?maprotator!oskari-frontend/packages/mapping/ol/maprotator/bundle.js';

--- a/applications/embedded/main.js
+++ b/applications/embedded/main.js
@@ -14,9 +14,9 @@ import 'oskari-loader!oskari-frontend/packages/mapping/ol/drawtools/bundle.js';
 
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/coordinatetool/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/publishedstatehandler/bundle.js';
-import 'oskari-loader!oskari-frontend/packages/framework/featuredata2/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/rpc/bundle.js';
 
+import 'oskari-lazy-loader?featuredata2!oskari-frontend/packages/framework/featuredata2/bundle.js';
 import 'oskari-lazy-loader?statsgrid!oskari-frontend/packages/statistics/statsgrid/bundle.js';
 import 'oskari-lazy-loader?routingService!oskari-frontend/packages/framework/bundle/routingService/bundle.js';
 import 'oskari-lazy-loader?maprotator!oskari-frontend/packages/mapping/ol/maprotator/bundle.js';

--- a/applications/geoportal-3d/main.js
+++ b/applications/geoportal-3d/main.js
@@ -21,7 +21,6 @@ import 'oskari-loader!oskari-frontend/packages/mapping/ol/infobox/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol/heatmap/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/mapping/ol/maprotator/bundle.js';
 
-import 'oskari-loader!oskari-frontend/packages/framework/bundle/backendstatus/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/coordinatetool/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/guidedtour/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/layerlist/bundle.js';
@@ -41,7 +40,6 @@ import 'oskari-loader!oskari-frontend/packages/statistics/statsgrid/bundle.js';
 import 'oskari-loader!../../packages/sample/bundle/sample-info/bundle.js';
 
 import 'oskari-lazy-loader?printout!oskari-frontend/packages/framework/bundle/printout/bundle.js';
-import 'oskari-lazy-loader?postprocessor!oskari-frontend/packages/framework/bundle/postprocessor/bundle.js';
 import 'oskari-lazy-loader?admin-layereditor!oskari-frontend/packages/admin/bundle/admin-layereditor/bundle.js';
 import 'oskari-lazy-loader?admin-layerrights!oskari-frontend/packages/framework/bundle/admin-layerrights/bundle.js';
 import 'oskari-lazy-loader?admin!oskari-frontend/packages/admin/bundle/admin/bundle.js';

--- a/applications/geoportal/main.js
+++ b/applications/geoportal/main.js
@@ -19,13 +19,9 @@ import 'oskari-loader!oskari-frontend/packages/mapping/ol/maprotator/bundle.js';
 import 'oskari-lazy-loader?metadatacatalogue!oskari-frontend/packages/catalogue/metadatacatalogue/bundle.js';
 import 'oskari-lazy-loader?metadataflyout!oskari-frontend/packages/catalogue/bundle/metadataflyout/bundle.js';
 
-import 'oskari-loader!oskari-frontend/packages/framework/bundle/backendstatus/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/coordinatetool/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/guidedtour/bundle.js';
-
-// only one of these will be shown based on the app
-import 'oskari-lazy-loader?layerlist!oskari-frontend/packages/framework/layerlist/bundle.js';
-import 'oskari-lazy-loader?hierarchical-layerlist!oskari-frontend/packages/framework/bundle/hierarchical-layerlist/bundle.js';
+import 'oskari-loader!oskari-frontend/packages/framework/layerlist/bundle.js';
 
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/maplegend/bundle.js';
 import 'oskari-loader!oskari-frontend/packages/framework/bundle/myplaces3/bundle.js';
@@ -47,7 +43,6 @@ import 'oskari-loader!oskari-frontend/packages/mapping/dimension-change/bundle.j
 import 'oskari-loader!../../packages/sample/bundle/sample-info/bundle.js';
 
 import 'oskari-lazy-loader?printout!oskari-frontend/packages/framework/bundle/printout/bundle.js';
-import 'oskari-lazy-loader?postprocessor!oskari-frontend/packages/framework/bundle/postprocessor/bundle.js';
 import 'oskari-lazy-loader?admin-layereditor!oskari-frontend/packages/admin/bundle/admin-layereditor/bundle.js';
 import 'oskari-lazy-loader?admin-layerrights!oskari-frontend/packages/framework/bundle/admin-layerrights/bundle.js';
 


### PR DESCRIPTION
 or don't make sense in the sample. For removed bundles ref: https://github.com/oskariorg/oskari-docs/issues/245

The postprocessor and backendstatus were not removed but they don't really make sense for the sample-application as they require certain backend functionalities that sample doesn't use.